### PR TITLE
Fix missing metadata.txt for deploy rule in Makefile

### DIFF
--- a/templateclass/Makefile.tmpl
+++ b/templateclass/Makefile.tmpl
@@ -33,7 +33,7 @@ PLUGINNAME = ${templateclass}
 
 PY_FILES = ${templateclass}.py ${templateclass}dialog.py __init__.py
 
-EXTRAS = icon.png 
+EXTRAS = icon.png metadata.txt
 
 UI_FILES = ui_${templateclass}.py
 


### PR DESCRIPTION
metadata.txt was not deployed when doing a "make deploy", leading to qgis not detecting the plugin.
Since future 2.0 only takes metadata.txt for plugins detection, this is worth a bugfix release.
