### PR TITLE
import qgis in test.__init__ 

### DIFF
--- a/plugin_template/test/__init__.py
+++ b/plugin_template/test/__init__.py
@@ -1,1 +1,2 @@
-__author__ = 'timlinux'
+# import qgis libs so that ve set the correct sip api version
+import qgis   # pylint: disable=W0611  # NOQA


### PR DESCRIPTION
import qgis libs so that we set the correct sip api version for all the created tests. what do you think @timlinux 
cheers
Marco
