### PR TITLE
fix typo in shared/Makefile.tmpl

### DIFF
--- a/plugin_templates/shared/Makefile.tmpl
+++ b/plugin_templates/shared/Makefile.tmpl
@@ -71,7 +71,7 @@ default: compile
 
 compile: $$(COMPILED_RESOURCE_FILES)
 
-%.py : %.qrc $$(RESOURCES_SRC)
+%.py : %.qrc $$(RESOURCE_SRC)
 	pyrcc4 -o $$*.py  $$<
 
 %.qm : %.ts


### PR DESCRIPTION
I'm not exactly sure what the makefile is doing here (just starting to learn about make) but I think this pull request is fixing a typo in the Makefile.tmpl. Please review carefully.

I've removed the extra 'S' from the variable name to match the definition several lines above.
