### PR TITLE
add ability to group plugins on menus and toolbars

### DIFF
--- a/plugin_templates/toolbutton_with_dialog/plugin_template.py
+++ b/plugin_templates/toolbutton_with_dialog/plugin_template.py
@@ -35,6 +35,7 @@ class ToolbuttonWithDialogPluginTemplate(PluginTemplate):
 
     def template_map(self, specification, dialog):
         menu_text = dialog.template_subframe.menu_text.text()
+
         menu = dialog.template_subframe.menu_location.currentText()
         # Munge the plugin menu function based on user choice
         if menu == 'Plugins':
@@ -44,6 +45,9 @@ class ToolbuttonWithDialogPluginTemplate(PluginTemplate):
             add_method = 'addPluginTo{}Menu'.format(menu)
             remove_method = 'removePlugin{}Menu'.format(menu)
         self.category = menu
+
+        group_name = dialog.template_subframe.group_name.text().strip()
+
         return {
             # Makefile
             'TemplatePyFiles': '%s_dialog.py' % specification.module_name,
@@ -55,6 +59,7 @@ class ToolbuttonWithDialogPluginTemplate(PluginTemplate):
             'TemplateMenuText': menu_text,
             'TemplateMenuAddMethod': add_method,
             'TemplateMenuRemoveMethod': remove_method,
+            'TemplateGroupName': group_name,
         }
 
     def template_files(self, specification):

--- a/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
@@ -21,9 +21,11 @@
  ***************************************************************************/
 """
 from PyQt4.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
-from PyQt4.QtGui import QAction, QIcon
+from PyQt4.QtGui import QAction, QIcon, QToolBar
+
 # Initialize Qt resources from file resources.py
 import resources
+
 # Import the code for the dialog
 from ${TemplateModuleName}_dialog import ${TemplateClass}Dialog
 import os.path
@@ -63,10 +65,22 @@ class ${TemplateClass}:
 
         # Declare instance attributes
         self.actions = []
-        self.menu = self.tr(u'&${TemplateTitle}')
-        # TODO: We are going to let the user set this up in a future iteration
-        self.toolbar = self.iface.addToolBar(u'${TemplateClass}')
-        self.toolbar.setObjectName(u'${TemplateClass}')
+
+        # The groupName statement is created from a template in PluginBuilder
+        # from user input. If no group name is entered the left side of
+        # the 'or' will be an empty string
+        groupName = u'${TemplateGroupName}' or u'${TemplateTitle}'
+
+        self.menu = self.tr(groupName)
+        self.toolbar = self.iface.mainWindow().findChild(QToolBar, groupName)
+        if not self.toolbar:
+            self.toolbar = self.iface.addToolBar(groupName)
+            self.toolbar.setObjectName(groupName)
+
+            # set toolbar color (light blue #ADD8E6 173,216,230)
+            # NOTE: color set in 1st plugin of the group loaded will be used
+            self.toolbar.setStyleSheet("QToolBar{background-color:#ADD8E6; border: 0px solid black}")
+
 
     # noinspection PyMethodMayBeStatic
     def tr(self, message):

--- a/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
@@ -69,13 +69,13 @@ class ${TemplateClass}:
         # The groupName statement is created from a template in PluginBuilder
         # from user input. If no group name is entered the left side of
         # the 'or' will be an empty string
-        groupName = u'${TemplateGroupName}' or u'${TemplateTitle}'
+        self.groupName = self.tr(u'${TemplateGroupName}' or u'${TemplateTitle}')
 
-        self.menu = self.tr(groupName)
-        self.toolbar = self.iface.mainWindow().findChild(QToolBar, groupName)
+        self.menu = self.groupName
+        self.toolbar = self.iface.mainWindow().findChild(QToolBar, self.groupName)
         if not self.toolbar:
-            self.toolbar = self.iface.addToolBar(groupName)
-            self.toolbar.setObjectName(groupName)
+            self.toolbar = self.iface.addToolBar(self.groupName)
+            self.toolbar.setObjectName(self.groupName)
 
             # set toolbar color (light blue #ADD8E6 173,216,230)
             # NOTE: color set in 1st plugin of the group loaded will be used
@@ -185,10 +185,8 @@ class ${TemplateClass}:
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
         for action in self.actions:
-            self.iface.${TemplateMenuRemoveMethod}(
-                self.tr(u'&${TemplateTitle}'),
-                action)
-            self.iface.removeToolBarIcon(action)
+            self.iface.${TemplateMenuRemoveMethod}(self.groupName, action)
+            self.toolbar.removeAction(action)
         # remove the toolbar
         del self.toolbar
 

--- a/plugin_templates/toolbutton_with_dialog/wizard_form_base.ui
+++ b/plugin_templates/toolbutton_with_dialog/wizard_form_base.ui
@@ -6,11 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>699</width>
-    <height>153</height>
+    <width>474</width>
+    <height>216</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>30</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="menu_label">
      <property name="minimumSize">
@@ -65,28 +78,24 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="menu_text_label">
-     <property name="minimumSize">
-      <size>
-       <width>150</width>
-       <height>0</height>
-      </size>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="group_name">
+     <property name="toolTip">
+      <string>This is the text that will appear as a sub-menu in the menu  e.g. Photo plugins.
+ Plugins with the same Group will be grouped together in a sub-menu and/or toolbar.</string>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
+     <property name="placeholderText">
+      <string>e.g. Photo tools (leave blank for no group)</string>
      </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Text for the menu item</string>
+      <string>Menu/Toolbar Group</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>menu_text</cstring>
      </property>
     </widget>
    </item>
@@ -116,18 +125,30 @@ name e.g. Link photos to points.</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
+   <item row="0" column="0">
+    <widget class="QLabel" name="menu_text_label">
+     <property name="minimumSize">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>150</width>
+       <height>0</height>
       </size>
      </property>
-    </spacer>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Text for the menu item</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>menu_text</cstring>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/plugin_templates/toolbutton_with_dockwidget/plugin_template.py
+++ b/plugin_templates/toolbutton_with_dockwidget/plugin_template.py
@@ -24,7 +24,6 @@
 import os
 from ..plugin_template import PluginTemplate
 
-
 class ToolbuttonWithDockWidgetPluginTemplate(PluginTemplate):
 
     def descr(self):
@@ -35,6 +34,7 @@ class ToolbuttonWithDockWidgetPluginTemplate(PluginTemplate):
 
     def template_map(self, specification, dialog):
         menu_text = dialog.template_subframe.menu_text.text()
+
         menu = dialog.template_subframe.menu_location.currentText()
         # Munge the plugin menu function based on user choice
         if menu == 'Plugins':
@@ -45,6 +45,7 @@ class ToolbuttonWithDockWidgetPluginTemplate(PluginTemplate):
             remove_method = 'removePlugin{}Menu'.format(menu)
         self.category = menu
 
+        group_name = dialog.template_subframe.group_name.text().strip()
         dockwidget_area = dialog.template_subframe.dockwidget_area.currentText()
 
         return {
@@ -58,8 +59,9 @@ class ToolbuttonWithDockWidgetPluginTemplate(PluginTemplate):
             'TemplateMenuText': menu_text,
             'TemplateMenuAddMethod': add_method,
             'TemplateMenuRemoveMethod': remove_method,
+            'TemplateGroupName': group_name,
             # DockWidget
-            'TemplateDockWidgetArea': 'Qt.{}DockWidgetArea'.format(dockwidget_area)
+            'TemplateDockWidgetArea': 'Qt.{}DockWidgetArea'.format(dockwidget_area),
         }
 
     def template_files(self, specification):

--- a/plugin_templates/toolbutton_with_dockwidget/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dockwidget/template/module_name.tmpl
@@ -68,13 +68,13 @@ class ${TemplateClass}:
         # The groupName statement is created from a template in PluginBuilder
         # from user input. If no group name is entered the left side of
         # the 'or' will be an empty string
-        groupName = u'${TemplateGroupName}' or u'${TemplateTitle}'
+        self.groupName = self.tr(u'${TemplateGroupName}' or u'${TemplateTitle}')
 
-        self.menu = self.tr(groupName)
-        self.toolbar = self.iface.mainWindow().findChild(QToolBar, groupName)
+        self.menu = self.groupName
+        self.toolbar = self.iface.mainWindow().findChild(QToolBar, self.groupName)
         if not self.toolbar:
-            self.toolbar = self.iface.addToolBar(groupName)
-            self.toolbar.setObjectName(groupName)
+            self.toolbar = self.iface.addToolBar(self.groupName)
+            self.toolbar.setObjectName(self.groupName)
 
             # set toolbar color (light blue #ADD8E6 173,216,230)
             # NOTE: color set in 1st plugin of the group loaded will be used
@@ -211,10 +211,8 @@ class ${TemplateClass}:
         #print "** UNLOAD ${TemplateClass}"
 
         for action in self.actions:
-            self.iface.${TemplateMenuRemoveMethod}(
-                self.tr(u'&${TemplateTitle}'),
-                action)
-            self.iface.removeToolBarIcon(action)
+            self.iface.${TemplateMenuRemoveMethod}(self.groupName, action)
+            self.toolbar.removeAction(action)
         # remove the toolbar
         del self.toolbar
 

--- a/plugin_templates/toolbutton_with_dockwidget/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dockwidget/template/module_name.tmpl
@@ -21,7 +21,8 @@
  ***************************************************************************/
 """
 from PyQt4.QtCore import QSettings, QTranslator, qVersion, QCoreApplication, Qt
-from PyQt4.QtGui import QAction, QIcon
+from PyQt4.QtGui import QAction, QIcon, QToolBar
+
 # Initialize Qt resources from file resources.py
 import resources
 
@@ -63,10 +64,21 @@ class ${TemplateClass}:
 
         # Declare instance attributes
         self.actions = []
-        self.menu = self.tr(u'&${TemplateTitle}')
-        # TODO: We are going to let the user set this up in a future iteration
-        self.toolbar = self.iface.addToolBar(u'${TemplateClass}')
-        self.toolbar.setObjectName(u'${TemplateClass}')
+
+        # The groupName statement is created from a template in PluginBuilder
+        # from user input. If no group name is entered the left side of
+        # the 'or' will be an empty string
+        groupName = u'${TemplateGroupName}' or u'${TemplateTitle}'
+
+        self.menu = self.tr(groupName)
+        self.toolbar = self.iface.mainWindow().findChild(QToolBar, groupName)
+        if not self.toolbar:
+            self.toolbar = self.iface.addToolBar(groupName)
+            self.toolbar.setObjectName(groupName)
+
+            # set toolbar color (light blue #ADD8E6 173,216,230)
+            # NOTE: color set in 1st plugin of the group loaded will be used
+            self.toolbar.setStyleSheet("QToolBar{background-color:#ADD8E6; border: 0px solid black}")
 
         #print "** INITIALIZING ${TemplateClass}"
 

--- a/plugin_templates/toolbutton_with_dockwidget/wizard_form_base.ui
+++ b/plugin_templates/toolbutton_with_dockwidget/wizard_form_base.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>699</width>
+    <width>474</width>
     <height>216</height>
    </rect>
   </property>
@@ -30,6 +30,104 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="menu_text">
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>This is the text that will appear in the menu under your Plugin
+name e.g. Link photos to points.</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>e.g. Link photos to points</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>30</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="dockwidget_area">
+     <item>
+      <property name="text">
+       <string>Left</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Right</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Top</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Dock Widget Area</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="menu_text_label">
+     <property name="minimumSize">
+      <size>
+       <width>150</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Text for the menu item</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>menu_text</cstring>
      </property>
     </widget>
    </item>
@@ -65,101 +163,24 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="menu_text">
-     <property name="minimumSize">
-      <size>
-       <width>300</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>This is the text that will appear in the menu under your Plugin
-name e.g. Link photos to points.</string>
-     </property>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string/>
-     </property>
-     <property name="placeholderText">
-      <string>e.g. Link photos to points</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>30</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="menu_text_label">
-     <property name="minimumSize">
-      <size>
-       <width>150</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Text for the menu item</string>
+      <string>Menu/Toolbar Group</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>menu_text</cstring>
      </property>
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QComboBox" name="dockwidget_area">
-     <item>
-      <property name="text">
-       <string>Left</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Right</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Top</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Bottom</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>DockWidget Area</string>
+    <widget class="QLineEdit" name="group_name">
+     <property name="toolTip">
+      <string>This is the text that will appear as a sub-menu in the menu  e.g. Photo plugins.
+ Plugins with the same Group will be grouped together in a sub-menu and/or toolbar.</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     <property name="placeholderText">
+      <string>e.g. Photo tools (leave blank for no group)</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This pull request adds the ability to have multiple plugins grouped together on a toolbar or in a submenu of a Main Menu item.  This is accomplished by adding a 'Group Name' which must be the same in all plugins of a group. 

The 'Group Name' is used as the plugin menu name. It is also used as the name and object name for the toolbar.  When initializing the plugin, a toolbar with the object name of 'Group Name' is searched for. If found that toolbar is used. Otherwise a new toolbar is created. The first plugin of a group creates the toolbar. When other plugins of the group are initialized, they will find the toolbar and use it.

Changes to Plugin Builder include adding an input for the 'Group Name' on each of the plugin specific 'widget_form_base_ui' forms. The code changes are the same in both the dialog plugin template and the dockwidget template.

If the person creating a plugin decides not to have a group and leaves the 'Group Name' empty, the value used will default to ${TemplateTitle} in module_name.tmpl.

I have let the 'Group Name' be a string with spaces.  I do not know if that will cause problems being used as the toolbar name and the toolbar object name.  I have not had any problems but am not familiar with how they may be used in QGIS.

I have also added a background color to the created toolbar. This is helpful in locating specific plugin groups. It may be confusing though. If you put a color in your plugin and another plugin in the group has a different color and is loaded first, that plugin wins and its color will used.  For this reason, feel free to comment out the section adding the color.
