### PR TITLE
Expansion of qgis_interface.py

### DIFF
--- a/plugin_templates/shared/test/qgis_interface.py
+++ b/plugin_templates/shared/test/qgis_interface.py
@@ -29,6 +29,41 @@ from qgis.core import QgsMapLayerRegistry
 from qgis.gui import QgsMapCanvasLayer
 LOGGER = logging.getLogger('QGIS')
 
+class QgisMessageBar(QObject):
+    """Class to simulate some QgsMessageBar behavior from unit testing.
+
+    This class is here for enabling us to run unit tests only,
+    so most methods are simply stubs.
+    """
+    def popWidget(self):
+        pass
+
+class QgisLegendInterface(QObject):
+    """Class to simulate some QgsLegendInterface behavior from unit testing.
+
+    This class is here for enabling us to run unit tests only,
+    so most methods are simply stubs.
+    """
+    def __init__(self):
+        """Constructor
+        """
+        QObject.__init__(self)
+        self.lgroups = []
+
+    def addGroup(self, groupname):
+        """Handle groups being added to the legend.
+           Added group strings will be returned when groups() is called."""
+        self.lgroups.append(groupname)
+
+    def groups(self):
+        return self.lgroups
+
+    def moveLayer(self, lyr, groupIndex):
+        pass
+
+    def setLayerVisible(self, lyr, isvis):
+        pass
+
 
 #noinspection PyMethodMayBeStatic,PyPep8Naming
 class QgisInterface(QObject):
@@ -54,9 +89,10 @@ class QgisInterface(QObject):
         QgsMapLayerRegistry.instance().layerWasAdded.connect(self.addLayer)
         # noinspection PyArgumentList
         QgsMapLayerRegistry.instance().removeAll.connect(self.removeAllLayers)
-
+        self.active_layer = None
         # For processing module
         self.destCrs = None
+        self.legend = QgisLegendInterface()
 
     @pyqtSlot('QStringList')
     def addLayers(self, layers):
@@ -150,9 +186,12 @@ class QgisInterface(QObject):
     def activeLayer(self):
         """Get pointer to the active layer (layer selected in the legend)."""
         # noinspection PyArgumentList
-        layers = QgsMapLayerRegistry.instance().mapLayers()
-        for item in layers:
-            return layers[item]
+        return self.active_layer
+
+    def setActiveLayer(self, layer):
+        """Get pointer to the active layer (layer selected in the legend)."""
+        # noinspection PyArgumentList
+        self.active_layer = layer
 
     def addToolBarIcon(self, action):
         """Add an icon to the plugins toolbar.
@@ -202,4 +241,8 @@ class QgisInterface(QObject):
 
     def legendInterface(self):
         """Get the legend."""
-        return self.canvas
+        return self.legend
+
+    def messageBar(self):
+        return QgisMessageBar()
+

--- a/plugin_templates/shared/test/qgis_interface.py
+++ b/plugin_templates/shared/test/qgis_interface.py
@@ -56,12 +56,20 @@ class QgisLegendInterface(QObject):
         self.lgroups.append(groupname)
 
     def groups(self):
+        """Handle request for legend groupnames
+        :return list of string groupnames"""
         return self.lgroups
 
     def moveLayer(self, lyr, groupIndex):
+        """Stub to handle moving a layer into a group by index
+        :lyr  the layer object
+        :groupIndex the index of the group in the legend"""
         pass
 
     def setLayerVisible(self, lyr, isvis):
+        """Stub to handle setting the visibility of a layer
+        :lyr layer object
+        :isvis bool to set visible"""
         pass
 
 
@@ -190,7 +198,6 @@ class QgisInterface(QObject):
 
     def setActiveLayer(self, layer):
         """Get pointer to the active layer (layer selected in the legend)."""
-        # noinspection PyArgumentList
         self.active_layer = layer
 
     def addToolBarIcon(self, action):
@@ -240,9 +247,10 @@ class QgisInterface(QObject):
         pass
 
     def legendInterface(self):
-        """Get the legend."""
+        """Get stub for  QgsLegendInterface."""
         return self.legend
 
     def messageBar(self):
+        """get stub for QgsMessageBar"""
         return QgisMessageBar()
 

--- a/test/qgis_interface.py
+++ b/test/qgis_interface.py
@@ -32,6 +32,49 @@ from qgis.core import QgsMapLayerRegistry
 from qgis.gui import QgsMapCanvasLayer
 LOGGER = logging.getLogger('InaSAFE')
 
+class QgisMessageBar(QObject):
+    """Class to simulate some QgsMessageBar behavior from unit testing.
+
+    This class is here for enabling us to run unit tests only,
+    so most methods are simply stubs.
+    """
+    def popWidget(self):
+        pass
+
+class QgisLegendInterface(QObject):
+    """Class to simulate some QgsLegendInterface behavior from unit testing.
+
+    This class is here for enabling us to run unit tests only,
+    so most methods are simply stubs.
+    """
+    def __init__(self):
+        """Constructor
+        """
+        QObject.__init__(self)
+        self.lgroups = []
+
+    def addGroup(self, groupname):
+        """Handle groups being added to the legend.
+           Added group strings will be returned when groups() is called."""
+        self.lgroups.append(groupname)
+
+    def groups(self):
+        """Handle request for legend groupnames
+        :return list of string groupnames"""
+        return self.lgroups
+
+    def moveLayer(self, lyr, groupIndex):
+        """Stub to handle moving a layer into a group by index
+        :lyr  the layer object
+        :groupIndex the index of the group in the legend"""
+        pass
+
+    def setLayerVisible(self, lyr, isvis):
+        """Stub to handle setting the visibility of a layer
+        :lyr layer object
+        :isvis bool to set visible"""
+        pass
+
 
 #noinspection PyMethodMayBeStatic,PyPep8Naming
 class QgisInterface(QObject):
@@ -57,9 +100,10 @@ class QgisInterface(QObject):
         QgsMapLayerRegistry.instance().layerWasAdded.connect(self.addLayer)
         # noinspection PyArgumentList
         QgsMapLayerRegistry.instance().removeAll.connect(self.removeAllLayers)
-
+        self.active_layer = None
         # For processing module
         self.destCrs = None
+        self.legend = QgisLegendInterface()
 
     @pyqtSlot('QStringList')
     def addLayers(self, layers):
@@ -153,9 +197,11 @@ class QgisInterface(QObject):
     def activeLayer(self):
         """Get pointer to the active layer (layer selected in the legend)."""
         # noinspection PyArgumentList
-        layers = QgsMapLayerRegistry.instance().mapLayers()
-        for item in layers:
-            return layers[item]
+        return self.active_layer
+
+    def setActiveLayer(self, layer):
+        """Get pointer to the active layer (layer selected in the legend)."""
+        self.active_layer = layer
 
     def addToolBarIcon(self, action):
         """Add an icon to the plugins toolbar.
@@ -204,5 +250,10 @@ class QgisInterface(QObject):
         pass
 
     def legendInterface(self):
-        """Get the legend."""
-        return self.canvas
+        """Get stub for  QgsLegendInterface."""
+        return self.legend
+
+    def messageBar(self):
+        """get stub for QgsMessageBar"""
+        return QgisMessageBar()
+

--- a/test/qgis_interface.py
+++ b/test/qgis_interface.py
@@ -32,6 +32,41 @@ from qgis.core import QgsMapLayerRegistry
 from qgis.gui import QgsMapCanvasLayer
 LOGGER = logging.getLogger('InaSAFE')
 
+class QgisMessageBar(QObject):
+    """Class to simulate some QgsMessageBar behavior from unit testing.
+
+    This class is here for enabling us to run unit tests only,
+    so most methods are simply stubs.
+    """
+    def popWidget(self):
+        pass
+
+class QgisLegendInterface(QObject):
+    """Class to simulate some QgsLegendInterface behavior from unit testing.
+
+    This class is here for enabling us to run unit tests only,
+    so most methods are simply stubs.
+    """
+    def __init__(self):
+        """Constructor
+        """
+        QObject.__init__(self)
+        self.lgroups = []
+
+    def addGroup(self, groupname):
+        """Handle groups being added to the legend.
+           Added group strings will be returned when groups() is called."""
+        self.lgroups.append(groupname)
+
+    def groups(self):
+        return self.lgroups
+
+    def moveLayer(self, lyr, groupIndex):
+        pass
+
+    def setLayerVisible(self, lyr, isvis):
+        pass
+
 
 #noinspection PyMethodMayBeStatic,PyPep8Naming
 class QgisInterface(QObject):
@@ -57,9 +92,10 @@ class QgisInterface(QObject):
         QgsMapLayerRegistry.instance().layerWasAdded.connect(self.addLayer)
         # noinspection PyArgumentList
         QgsMapLayerRegistry.instance().removeAll.connect(self.removeAllLayers)
-
+        self.active_layer = None
         # For processing module
         self.destCrs = None
+        self.legend = QgisLegendInterface()
 
     @pyqtSlot('QStringList')
     def addLayers(self, layers):
@@ -153,9 +189,11 @@ class QgisInterface(QObject):
     def activeLayer(self):
         """Get pointer to the active layer (layer selected in the legend)."""
         # noinspection PyArgumentList
-        layers = QgsMapLayerRegistry.instance().mapLayers()
-        for item in layers:
-            return layers[item]
+        return self.active_layer
+
+    def setActiveLayer(self, layer):
+        """Get pointer to the active layer (layer selected in the legend)."""
+        self.active_layer = layer
 
     def addToolBarIcon(self, action):
         """Add an icon to the plugins toolbar.
@@ -204,5 +242,10 @@ class QgisInterface(QObject):
         pass
 
     def legendInterface(self):
-        """Get the legend."""
-        return self.canvas
+        """Get the stub for QgsLegendInterface."""
+        return self.legend
+
+    def messageBar(self):
+        """get the stub for QgsMessageBar"""
+        return QgisMessageBar()
+


### PR DESCRIPTION
I have been doing a lot of unit testing lately and I found it neccessary to expand the qgis_interface.py to accomodate my plugin's calls to iface.  It would be nice if these changes were added to the plugin template, providing they are useful.

I have added stub classes to simulate QgsMessageBar and QgsLegendInterface.

I added a setActiveLayer function and changed the behavior of the activeLayer function so that it Returns the layer set by setActiveLayer, instead of the first layer in the layer list.

I changed the behavior of the legendInterface function to return the stub legend Interface class instead of the canvas object.

I added a messageBar function that Returns a stub message bar class.
