### PR TITLE
Fix typos in templates for dialogs/dock widgets

### DIFF
--- a/plugin_templates/toolbutton_with_dialog/template/readme.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/readme.tmpl
@@ -21,7 +21,7 @@ What's Next:
 
   * Create your own custom icon, replacing the default icon.png
 
-  * Modify your user interface by opening ${TemplateClass}.ui in Qt Designer
+  * Modify your user interface by opening ${TemplateClass}_dialog_base.ui in Qt Designer
 
   * You can use the Makefile to compile your Ui and resource files when
     you make changes. This requires GNU make (gmake)

--- a/plugin_templates/toolbutton_with_dockwidget/template/readme.tmpl
+++ b/plugin_templates/toolbutton_with_dockwidget/template/readme.tmpl
@@ -21,7 +21,7 @@ What's Next:
 
   * Create your own custom icon, replacing the default icon.png
 
-  * Modify your user interface by opening ${TemplateClass}.ui in Qt Designer
+  * Modify your user interface by opening ${TemplateClass}_dockwidget_base.ui in Qt Designer
 
   * You can use the Makefile to compile your Ui and resource files when
     you make changes. This requires GNU make (gmake)

--- a/plugin_templates/toolbutton_with_dockwidget/template/results.tmpl
+++ b/plugin_templates/toolbutton_with_dockwidget/template/results.tmpl
@@ -19,7 +19,7 @@ Your QGIS plugin directory is located at:<br>
     <li>Test the plugin by enabling it in the QGIS plugin manager
     <li>Customize it by editing the implementation file <b>${TemplateModuleName}.py</b>
     <li>Create your own custom icon, replacing the default <b>icon.png</b>
-    <li>Modify your user interface by opening <b>${TemplateModuleName}_dialog_base.ui</b> in Qt Designer
+    <li>Modify your user interface by opening <b>${TemplateModuleName}_dockwidget_base.ui</b> in Qt Designer
 </ol>
 Notes:
 <ul>


### PR DESCRIPTION
Fixes (issue #71) relating to typos in results/readme messages, specifically around:

"Modify your user interface by opening <b>${TemplateModuleName}_<xxx>.ui</b> in Qt Designer"

to make the messages refer to the correct files.