### PR TITLE
updated usage of pyrcc in docs

### DIFF
--- a/help/source/index.rst
+++ b/help/source/index.rst
@@ -264,10 +264,10 @@ it is functional in QGIS.
 The resource file contains definitions of media used in your plugin. Upon
 generation, this contains one entry for icon.png, the icon file for the plugin.
 
-To compile the resource file into Python code, use the ``pyrcc4`` utility
+To compile the resource file into Python code, use the ``pyrcc5`` utility
 that comes as part of your PyQt installation::
 
-  pyrcc4 -o resources.py resources.qrc
+  pyrcc5 -o resources.py resources.qrc
 
 
 Once the resource file is compiled, the generated plugin can be loaded in QGIS.

--- a/plugin_templates/toolbutton_with_dialog/template/readme.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/readme.tmpl
@@ -11,7 +11,7 @@ What's Next:
   * Copy the entire directory containing your new plugin to the QGIS plugin
     directory
 
-  * Compile the resources file using pyrcc4
+  * Compile the resources file using pyrcc5
 
   * Run the tests (``make test``)
 

--- a/plugin_templates/toolbutton_with_dockwidget/template/readme.tmpl
+++ b/plugin_templates/toolbutton_with_dockwidget/template/readme.tmpl
@@ -11,7 +11,7 @@ What's Next:
   * Copy the entire directory containing your new plugin to the QGIS plugin
     directory
 
-  * Compile the resources file using pyrcc4
+  * Compile the resources file using pyrcc5
 
   * Run the tests (``make test``)
 


### PR DESCRIPTION
The documentation had some references to `pyrcc4` which would not be correct for the QGIS3 version. Fix is necessary because the user will get to see the advice to use `pyrcc4` instead of `pyrcc5` at the end of the Plugin-Builder process.