### PR TITLE
New plugin classes now inherits from `object`

### DIFF
--- a/plugin_templates/processing_provider/template/module_name.tmpl
+++ b/plugin_templates/processing_provider/template/module_name.tmpl
@@ -42,7 +42,7 @@ if cmd_folder not in sys.path:
     sys.path.insert(0, cmd_folder)
 
 
-class ${TemplateClass}Plugin:
+class ${TemplateClass}Plugin(object):
 
     def __init__(self):
         self.provider = ${TemplateClass}Provider()

--- a/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
@@ -29,7 +29,7 @@ from ${TemplateModuleName}_dialog import ${TemplateClass}Dialog
 import os.path
 
 
-class ${TemplateClass}:
+class ${TemplateClass}(object):
     """QGIS Plugin Implementation."""
 
     def __init__(self, iface):

--- a/plugin_templates/toolbutton_with_dockwidget/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dockwidget/template/module_name.tmpl
@@ -30,7 +30,7 @@ from ${TemplateModuleName}_dockwidget import ${TemplateClass}DockWidget
 import os.path
 
 
-class ${TemplateClass}:
+class ${TemplateClass}(object):
     """QGIS Plugin Implementation."""
 
     def __init__(self, iface):


### PR DESCRIPTION
It fixes the plugin builder templates to ensure that new classes inherits from `object`.

Fix #82  New plugin templates should inherits from object