### PR TITLE
modified the default path for qgis3 plugin directory

### DIFF
--- a/plugin_templates/shared/Makefile.tmpl
+++ b/plugin_templates/shared/Makefile.tmpl
@@ -67,7 +67,7 @@ PLUGIN_UPLOAD = $$(c)/plugin_upload.py
 
 RESOURCE_SRC=$$(shell grep '^ *<file' ${TemplateQrcFiles} | sed 's@</file>@@g;s/.*>//g' | tr '\n' ' ')
 
-QGISDIR=.qgis2
+QGISDIR=.local/share/QGIS/QGIS3/profiles/default
 
 default: compile
 


### PR DESCRIPTION
I have quickly modified the default path for QGIS3 plugin folder in the template. (The problem is that I only know about the path fro Linux, and don’t know about OS-X.) Hopefully, this will be helpful.