### PR TITLE
relocate self.dlg = ${TemplateClass}Dialog() to self.run()

### DIFF
--- a/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
@@ -65,6 +65,10 @@ class ${TemplateClass}:
         self.actions = []
         self.menu = self.tr(u'&${TemplateTitle}')
 
+        # Check if plugin was started the first time in current QGIS session
+        # Will be set False once it was started
+        self.first_start = True
+
     # noinspection PyMethodMayBeStatic
     def tr(self, message):
         """Get the translation for a string using Qt translation API.
@@ -179,8 +183,10 @@ class ${TemplateClass}:
         """Run method that performs all the real work"""
 
         # Create the dialog with elements (after translation) and keep reference
-        # Only create GUI in callback, so that it will only load when the plugin is started
-        dlg = ${TemplateClass}Dialog()
+        # Only create GUI ONCE in callback, so that it will only load when the plugin is started
+        if self.first_start == True:
+            self.first_start = False
+            dlg = ${TemplateClass}Dialog()
 
         # show the dialog
         dlg.show()

--- a/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
@@ -61,15 +61,9 @@ class ${TemplateClass}:
             if qVersion() > '4.3.3':
                 QCoreApplication.installTranslator(self.translator)
 
-        # Create the dialog (after translation) and keep reference
-        self.dlg = ${TemplateClass}Dialog()
-
         # Declare instance attributes
         self.actions = []
         self.menu = self.tr(u'&${TemplateTitle}')
-        # TODO: We are going to let the user set this up in a future iteration
-        self.toolbar = self.iface.addToolBar(u'${TemplateClass}')
-        self.toolbar.setObjectName(u'${TemplateClass}')
 
     # noinspection PyMethodMayBeStatic
     def tr(self, message):
@@ -149,7 +143,8 @@ class ${TemplateClass}:
             action.setWhatsThis(whats_this)
 
         if add_to_toolbar:
-            self.toolbar.addAction(action)
+            # Adds plugin icon to Plugins toolbar
+            self.iface.addToolBarIcon(action)
 
         if add_to_menu:
             self.iface.${TemplateMenuAddMethod}(
@@ -178,16 +173,19 @@ class ${TemplateClass}:
                 self.tr(u'&${TemplateTitle}'),
                 action)
             self.iface.removeToolBarIcon(action)
-        # remove the toolbar
-        del self.toolbar
 
 
     def run(self):
         """Run method that performs all the real work"""
+
+        # Create the dialog with elements (after translation) and keep reference
+        # Only create GUI in callback, so that it will only load when the plugin is started
+        dlg = ${TemplateClass}Dialog()
+
         # show the dialog
-        self.dlg.show()
+        dlg.show()
         # Run the dialog event loop
-        result = self.dlg.exec_()
+        result = dlg.exec_()
         # See if OK was pressed
         if result:
             # Do something useful here - delete the line containing pass and

--- a/plugin_templates/toolbutton_with_dialog/template/module_name_dialog.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/module_name_dialog.tmpl
@@ -27,6 +27,7 @@ import os
 from PyQt5 import uic
 from PyQt5 import QtWidgets
 
+# This loads your .ui file so that PyQt can populate your plugin with the elements from Qt Designer
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), '${TemplateModuleName}_dialog_base.ui'))
 
@@ -35,8 +36,8 @@ class ${TemplateClass}Dialog(QtWidgets.QDialog, FORM_CLASS):
     def __init__(self, parent=None):
         """Constructor."""
         super(${TemplateClass}Dialog, self).__init__(parent)
-        # Set up the user interface from Designer.
-        # After setupUI you can access any designer object by doing
+        # Set up the user interface from Designer through FORM_CLASS.
+        # After self.setupUi() you can access any designer object by doing
         # self.<objectname>, and you can use autoconnect slots - see
         # http://qt-project.org/doc/qt-4.8/designer-using-a-ui-file.html
         # #widgets-and-dialogs-with-auto-connect


### PR DESCRIPTION
In the current implementation, the plugin dialog is populated in the plugin's main class `__init__`, i.e. it's populated when QGIS starts up. This **seriously impacts** QGIS startup performance, if all plugins would do that. And a lot do, since they're built with Plugin Builder 3.

Change: populate the plugin GUI in `self.run()`, so that it only is called when the plugin is called.