### PR TITLE
Hotfix: self.first_start was still False on plugin reload

### DIFF
--- a/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
+++ b/plugin_templates/toolbutton_with_dialog/template/module_name.tmpl
@@ -66,8 +66,8 @@ class ${TemplateClass}:
         self.menu = self.tr(u'&${TemplateTitle}')
 
         # Check if plugin was started the first time in current QGIS session
-        # Will be set False once it was started
-        self.first_start = True
+        # Must be set in initGui() to survive plugin reloads
+        self.first_start = None
 
     # noinspection PyMethodMayBeStatic
     def tr(self, message):
@@ -168,6 +168,9 @@ class ${TemplateClass}:
             text=self.tr(u'$TemplateMenuText'),
             callback=self.run,
             parent=self.iface.mainWindow())
+
+        # will be set False in run()
+        self.first_start = None
 
 
     def unload(self):


### PR DESCRIPTION
When plugin was reloaded, `self.first_start` was still `False`, causing `self.dlg` to never be assigned and throw an error.

Moved `self.first_start = True` to `initGui()`, where it makes more sense. Sorry for that.. Also sorry for the `merge` commit, hope that's still acceptable to you..