### PR TITLE
update Processing template with initProcessing

### DIFF
--- a/plugin_builder.py
+++ b/plugin_builder.py
@@ -255,6 +255,8 @@ class PluginBuilder:
             replacement keys/values.
         :type specification: PluginSpecification
         """
+        processing_provider = (
+            specification.template_map.TemplateHasProcessingProvider)
         metadata_file = codecs.open(os.path.join(
             str(self.plugin_path), 'metadata.txt'), 'w', 'utf-8')
         metadata_comment = (
@@ -284,6 +286,9 @@ class PluginBuilder:
             '# End of mandatory metadata\n\n')
         metadata_file.write(
             '# Recommended items:\n\n')
+        metadata_file.write(
+            'hasProcessingProvider={}\n'.format(
+                'yes' if processing_provider else 'no'))
         metadata_file.write(
             '# Uncomment the following line and add your changelog:\n')
         metadata_file.write(

--- a/plugin_templates/processing_provider/plugin_template.py
+++ b/plugin_templates/processing_provider/plugin_template.py
@@ -40,6 +40,8 @@ class ProcessingProviderPluginTemplate(PluginTemplate):
         return {
             # Makefile
             'TemplateQGISDir': deployment_dir,
+            # Metadata
+            'TemplateHasProcessingProvider': True,
             # Processing
             'TemplateAlgoName': frame.algo_name_text.text(),
             'TemplateAlgoGroup': frame.algo_group_text.text(),

--- a/plugin_templates/processing_provider/template/module_name.tmpl
+++ b/plugin_templates/processing_provider/template/module_name.tmpl
@@ -34,7 +34,7 @@ import os
 import sys
 import inspect
 
-from qgis.core import QgsProcessingAlgorithm, QgsApplication
+from qgis.core import Qgis, QgsProcessingAlgorithm, QgsApplication
 from .${TemplateModuleName}_provider import ${TemplateClass}Provider
 
 cmd_folder = os.path.split(inspect.getfile(inspect.currentframe()))[0]
@@ -46,10 +46,16 @@ if cmd_folder not in sys.path:
 class ${TemplateClass}Plugin(object):
 
     def __init__(self):
+        self.provider = None
+
+    def initProcessing(self):
+        """Init Processing provider for QGIS >= 3.8."""
         self.provider = ${TemplateClass}Provider()
+        QgsApplication.processingRegistry().addProvider(self.provider)
 
     def initGui(self):
-        QgsApplication.processingRegistry().addProvider(self.provider)
+        if Qgis.QGIS_VERSION_INT < 30800:
+            self.initProcessing()
 
     def unload(self):
         QgsApplication.processingRegistry().removeProvider(self.provider)

--- a/plugin_templates/toolbutton_with_dialog/plugin_template.py
+++ b/plugin_templates/toolbutton_with_dialog/plugin_template.py
@@ -52,6 +52,8 @@ class ToolbuttonWithDialogPluginTemplate(PluginTemplate):
             'TemplateQrcFiles': 'resources.qrc',
             'TemplateRcFiles': "resources.py",
             'TemplateQGISDir': deployment_dir,
+            # Metadata
+            'TemplateHasProcessingProvider': False,
             # Menu
             'TemplateMenuText': menu_text,
             'TemplateMenuAddMethod': add_method,

--- a/plugin_templates/toolbutton_with_dockwidget/plugin_template.py
+++ b/plugin_templates/toolbutton_with_dockwidget/plugin_template.py
@@ -56,6 +56,8 @@ class ToolbuttonWithDockWidgetPluginTemplate(PluginTemplate):
             'TemplateQrcFiles': 'resources.qrc',
             'TemplateRcFiles': "resources.py",
             'TemplateQGISDir': deployment_dir,
+            # Metadata
+            'TemplateHasProcessingProvider': False,
             # Menu
             'TemplateMenuText': menu_text,
             'TemplateMenuAddMethod': add_method,


### PR DESCRIPTION
Fix #106

@nyalldawson Can you check the Processing part?
To make a plugin compatible QGIS < 3.8 and QGIS >= 3.8 at the same time.

@g-sherman I couldn't try, I coded blindly this PR. I have an error
`No module named 'Qgis-Plugin-Builder.qgis_dirs'`
I made a symlink of the git repo into `python/plugins` folder. I compiled the QRC file too. Any hint?
I didn't look deeper.