### PR TITLE
fix: remove gambling spam injection from zh translation

### DIFF
--- a/pluginbuilder4/i18n/zh.ts
+++ b/pluginbuilder4/i18n/zh.ts
@@ -421,7 +421,7 @@ It should be in CamelCase e.g. PhotoLinker.</source>
     <message>
         <location filename="../plugin_builder_dialog_base.ui" line="0" />
         <source>GitLab namespace:</source>
-        <translation>亚搏体育appGitLab命名空间：</translation>
+        <translation>GitLab命名空间：</translation>
     </message>
     <message>
         <location filename="../plugin_builder_dialog_base.ui" line="0" />


### PR DESCRIPTION
## Security: gambling spam injection in Chinese translation file

In `pluginbuilder4/i18n/zh.ts`, the translation for `GitLab namespace:`
was corrupted with prepended gambling site spam:

```xml
<source>GitLab namespace:</source>
<translation>亚搏体育appGitLab命名空间：</translation>
```

## Fix

Remove the injected text, restoring the correct translation:

```xml
<translation>GitLab命名空间：</translation>
```

## Context

This is a Chinese Qt translation file (TS format). The `<source>` is in
English (`GitLab namespace:`), and the `<translation>` should be the
Chinese equivalent. The gambling spam was prepended to the translation,
likely as an SEO injection attempt.

## File

- `pluginbuilder4/i18n/zh.ts` (line 424)